### PR TITLE
less stuttering with struct methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Instantiate a quaternion q = a_w + a_x * **i** + a_y * **j** + a_z * **k**:
 ```Go
 q1 := Quaternion{a_w, a_x, a_y, a_z}
 q2 := Quaternion{W: 0.5, X: 0.5, Y: -0.707, Z: -0.707}
+q3 := New(0.5,0.5,-0.707,-0.707)
 ```
 
 A number (scalar) can be created with Quaternion or with the Scalar function:
@@ -22,9 +23,14 @@ qk1 := Quaternion{W: -0.5}
 qk2 := Scalar(0.5)
 ```
 
+A pure quaternion with no scalar component:
+```Go
+q := Pure(0.5, -0.707, -0.707)
+```
+
 Calculate the conjugate q* = a_w - a_x * **i** - a_y * **j** - a_z * **k**:
 ```Go
-q5 := Conj(qr)
+q5 := qr.Conj()
 ```
 
 Calculate the sum as a new quaternion:
@@ -44,17 +50,17 @@ q5 := Prod(q4, q3, q1, q2)
 
 Calculate the norm ("length") and the squared norm:
 ```Go
-k := Norm(q5)
-k2 := Norm2(q5)
+k := q5.Norm()
+k2 := q5.Norm2()
 ```
 
 Convert to/from Euler angle representations:
 ```Go
 q1 := FromEuler(math.Pi/4, math.Pi/3, 5*math.Pi/3)
-phi, theta, psi := Euler(q1)
+phi, theta, psi := q1.Euler()
 ```
 
 Get the Rotation Matrix corresponding to a quaternion:
 ```Go
-m := RotMat(q1)
+m := q1.RotMat()
 ```

--- a/quaternion.go
+++ b/quaternion.go
@@ -12,10 +12,12 @@ import (
 	"math"
 )
 
+// New returns a new quaternion
 func New(w, x, y, z float64) Quaternion {
 	return Quaternion{W: w, X: x, Y: y, Z: z}
 }
 
+// Pure returns a new pure quaternion (no scalar part)
 func Pure(x, y, z float64) Quaternion {
 	return Quaternion{X: x, Y: y, Z: z}
 }
@@ -30,12 +32,10 @@ type Quaternion struct {
 
 // Conj returns the conjugate of a Quaternion (W,X,Y,Z) -> (W,-X,-Y,-Z)
 func (qin Quaternion) Conj() Quaternion {
-	qout := Quaternion{}
-	qout.W = +qin.W
-	qout.X = -qin.X
-	qout.Y = -qin.Y
-	qout.Z = -qin.Z
-	return qout
+	qin.X = -qin.X
+	qin.Y = -qin.Y
+	qin.Z = -qin.Z
+	return qin
 }
 
 // Norm2 returns the L2-Norm of a Quaternion (W,X,Y,Z) -> W*W+X*X+Y*Y+Z*Z
@@ -43,9 +43,18 @@ func (qin Quaternion) Norm2() float64 {
 	return qin.W*qin.W + qin.X*qin.X + qin.Y*qin.Y + qin.Z*qin.Z
 }
 
+// Neg returns the negative
+func (qin Quaternion) Neg() Quaternion {
+	qin.W = -qin.W
+	qin.X = -qin.X
+	qin.Y = -qin.Y
+	qin.Z = -qin.Z
+	return qin
+}
+
 // Norm returns the L1-Norm of a Quaternion (W,X,Y,Z) -> Sqrt(W*W+X*X+Y*Y+Z*Z)
 func (qin Quaternion) Norm() float64 {
-	return math.Sqrt(qin.W*qin.W + qin.X*qin.X + qin.Y*qin.Y + qin.Z*qin.Z)
+	return math.Sqrt(qin.Norm2())
 }
 
 // Scalar returns a scalar-only Quaternion representation of a float (W,0,0,0)

--- a/quaternion.go
+++ b/quaternion.go
@@ -12,6 +12,14 @@ import (
 	"math"
 )
 
+func New(w, x, y, z float64) Quaternion {
+	return Quaternion{W: w, X: x, Y: y, Z: z}
+}
+
+func Pure(x, y, z float64) Quaternion {
+	return Quaternion{X: x, Y: y, Z: z}
+}
+
 // Quaternion represents a quaternion W+X*i+Y*j+Z*k
 type Quaternion struct {
 	W float64 // Scalar component
@@ -21,7 +29,7 @@ type Quaternion struct {
 }
 
 // Conj returns the conjugate of a Quaternion (W,X,Y,Z) -> (W,-X,-Y,-Z)
-func Conj(qin Quaternion) Quaternion {
+func (qin Quaternion) Conj() Quaternion {
 	qout := Quaternion{}
 	qout.W = +qin.W
 	qout.X = -qin.X
@@ -31,12 +39,12 @@ func Conj(qin Quaternion) Quaternion {
 }
 
 // Norm2 returns the L2-Norm of a Quaternion (W,X,Y,Z) -> W*W+X*X+Y*Y+Z*Z
-func Norm2(qin Quaternion) float64 {
+func (qin Quaternion) Norm2() float64 {
 	return qin.W*qin.W + qin.X*qin.X + qin.Y*qin.Y + qin.Z*qin.Z
 }
 
 // Norm returns the L1-Norm of a Quaternion (W,X,Y,Z) -> Sqrt(W*W+X*X+Y*Y+Z*Z)
-func Norm(qin Quaternion) float64 {
+func (qin Quaternion) Norm() float64 {
 	return math.Sqrt(qin.W*qin.W + qin.X*qin.X + qin.Y*qin.Y + qin.Z*qin.Z)
 }
 
@@ -72,21 +80,21 @@ func Prod(qin ...Quaternion) Quaternion {
 }
 
 // Unit returns the Quaternion rescaled to unit-L1-norm
-func Unit(qin Quaternion) Quaternion {
-	k := Norm(qin)
+func (qin Quaternion) Unit() Quaternion {
+	k := qin.Norm()
 	return Quaternion{qin.W / k, qin.X / k, qin.Y / k, qin.Z / k}
 }
 
 // Inv returns the Quaternion conjugate rescaled so that Q Q* = 1
-func Inv(qin Quaternion) Quaternion {
-	k2 := Norm2(qin)
-	q := Conj(qin)
+func (qin Quaternion) Inv() Quaternion {
+	k2 := qin.Norm2()
+	q := qin.Conj()
 	return Quaternion{q.W / k2, q.X / k2, q.Y / k2, q.Z / k2}
 }
 
 // Euler returns the Euler angles phi, theta, psi corresponding to a Quaternion
-func Euler(q Quaternion) (float64, float64, float64) {
-	r := Unit(q)
+func (q Quaternion) Euler() (float64, float64, float64) {
+	r := q.Unit()
 	phi := math.Atan2(2*(r.W*r.X+r.Y*r.Z), 1-2*(r.X*r.X+r.Y*r.Y))
 	theta := math.Asin(2 * (r.W*r.Y - r.Z*r.X))
 	psi := math.Atan2(2*(r.X*r.Y+r.W*r.Z), 1-2*(r.Y*r.Y+r.Z*r.Z))
@@ -108,8 +116,8 @@ func FromEuler(phi, theta, psi float64) Quaternion {
 }
 
 // RotMat returns the rotation matrix (as float array) corresponding to a Quaternion
-func RotMat(qin Quaternion) [3][3]float64 {
-	q := Unit(qin)
+func (qin Quaternion) RotMat() [3][3]float64 {
+	q := qin.Unit()
 	m := [3][3]float64{}
 	m[0][0] = 1 - 2*(q.Y*q.Y+q.Z*q.Z)
 	m[0][1] = 2 * (q.X*q.Y - q.W*q.Z)

--- a/quaternion_test.go
+++ b/quaternion_test.go
@@ -59,19 +59,19 @@ func TestMixedSum(t *testing.T) {
 }
 
 func TestScalarConj(t *testing.T) {
-	if Conj(qs1) != qs1 {
+	if qs1.Conj() != qs1 {
 		t.Fail()
 	}
 }
 
 func TestVectorConj(t *testing.T) {
-	if Conj(qv4) != qv5 {
+	if qv4.Conj() != qv5 {
 		t.Fail()
 	}
 }
 
 func TestMixedConj(t *testing.T) {
-	if Conj(q2) != q3 {
+	if q2.Conj() != q3 {
 		t.Fail()
 	}
 }
@@ -95,37 +95,37 @@ func TestMixedProd(t *testing.T) {
 }
 
 func TestScalarNorm(t *testing.T) {
-	if Norm(qs4) != 110 {
+	if qs4.Norm() != 110 {
 		t.Fail()
 	}
 }
 
 func TestVectorNorm(t *testing.T) {
-	if Norm(qv4) != 3 {
+	if qv4.Norm() != 3 {
 		t.Fail()
 	}
 }
 
 func TestMixedNorm(t *testing.T) {
-	if Norm(q4) != 8 {
+	if q4.Norm() != 8 {
 		t.Fail()
 	}
 }
 
 func TestUnit(t *testing.T) {
-	if Unit(q4) != q5 {
+	if q4.Unit() != q5 {
 		t.Fail()
 	}
 }
 
 func TestInv(t *testing.T) {
-	if Inv(q4) != q6 {
+	if q4.Inv() != q6 {
 		t.Fail()
 	}
 }
 
 func TestEuler(t *testing.T) {
-	phi, theta, psi := Euler(q7)
+	phi, theta, psi := q7.Euler()
 	if math.Abs(phi-1.0) > 1e-6 ||
 		math.Abs(theta+0.3) > 1e-6 ||
 		math.Abs(psi-2.4) > 1e-6 {
@@ -145,7 +145,7 @@ func TestFromEuler(t *testing.T) {
 }
 
 func TestRotMat(t *testing.T) {
-	mm := RotMat(q9)
+	mm := q9.RotMat()
 	for i, x := range mm {
 		for j, y := range x {
 			if math.Abs(m[i][j]-y) > 1e-6 {


### PR DESCRIPTION
in starting to use the original package, i noticed alot of stuttering with "quaternion.*" everywhere in my code, so i could remove alot of those by attaching methods to the Quaternion struct itself, rather than calling methods like "Quaternion.Norm(...)". now it's just "q1.Norm()" where q1 is already a Quaternion type.